### PR TITLE
Skip ToArray call when map is empty

### DIFF
--- a/Glamaholic/Ui/MainInterface.cs
+++ b/Glamaholic/Ui/MainInterface.cs
@@ -1063,10 +1063,12 @@ namespace Glamaholic.Ui {
         }
 
         private void HandleTimers() {
-            var keys = this._timedMessages.Keys.ToArray();
-            foreach (var key in keys) {
-                if (this._timedMessages[key].Elapsed > TimeSpan.FromSeconds(5)) {
-                    this._timedMessages.Remove(key);
+            if (this._timedMessages.Count > 0) {
+                var keys = this._timedMessages.Keys.ToArray();
+                foreach (var key in keys) {
+                    if (this._timedMessages[key].Elapsed > TimeSpan.FromSeconds(5)) {
+                        this._timedMessages.Remove(key);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is an extremely minor change, but since `HandleTimers` is called every frame during UI `Draw`, we can reduce the overhead slightly by skipping an array allocation when the timer map is empty.