### PR TITLE
Add prev/next plate buttons and optional try-on sync

### DIFF
--- a/Glamaholic/Configuration.cs
+++ b/Glamaholic/Configuration.cs
@@ -98,6 +98,7 @@ namespace Glamaholic {
         public bool ShowTryOnMenu = true;
         public bool ShowKofiButton = true;
         public bool ItemFilterShowObtainedOnly;
+        public bool SyncTryOnWithSelection = true;
         public bool TroubleshootingMode = false;
 
         /// <summary>

--- a/Glamaholic/Ui/MainInterface.cs
+++ b/Glamaholic/Ui/MainInterface.cs
@@ -219,6 +219,7 @@ namespace Glamaholic.Ui {
                 anyChanged |= ImGui.MenuItem("Show plate editor menu", "", ref this.Ui.Plugin.Config.ShowEditorMenu);
                 anyChanged |= ImGui.MenuItem("Show examine window menu", "", ref this.Ui.Plugin.Config.ShowExamineMenu);
                 anyChanged |= ImGui.MenuItem("Show try on menu", "", ref this.Ui.Plugin.Config.ShowTryOnMenu);
+                anyChanged |= ImGui.MenuItem("Sync try on with selected plate", "", ref this.Ui.Plugin.Config.SyncTryOnWithSelection);
                 ImGui.Separator();
                 anyChanged |= ImGui.MenuItem("Show Ko-fi button", "", ref this.Ui.Plugin.Config.ShowKofiButton);
                 ImGui.Separator();
@@ -1099,9 +1100,15 @@ namespace Glamaholic.Ui {
 
         private void DrawPlateButtons(PlateNode node) {
             var plate = node.Plate!;
-            if (this._editing || !ImGui.BeginTable("plate buttons", 7, ImGuiTableFlags.SizingFixedFit)) {
+            if (this._editing || !ImGui.BeginTable("plate buttons", 10, ImGuiTableFlags.SizingFixedFit)) {
                 return;
             }
+
+            for (var i = 0; i < 7; i++)
+                ImGui.TableSetupColumn($"btn{i}");
+            ImGui.TableSetupColumn("spacer", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableSetupColumn("prev");
+            ImGui.TableSetupColumn("next");
 
             ImGui.TableNextColumn();
             if (Util.IconButton(FontAwesomeIcon.Check, tooltip: "Apply")) {
@@ -1157,6 +1164,28 @@ namespace Glamaholic.Ui {
                 }
                 ImGui.EndPopup();
             }
+
+            // Spacer column pushes nav buttons to the right
+            ImGui.TableNextColumn();
+
+            var visiblePlates = this.GetVisiblePlates();
+            var currentIndex = visiblePlates.FindIndex(p => p.id == node.Id);
+
+            ImGui.TableNextColumn();
+            var hasPrev = currentIndex > 0;
+            if (!hasPrev) ImGui.BeginDisabled();
+            if (Util.IconButton(FontAwesomeIcon.ChevronLeft, tooltip: "Previous plate")) {
+                this.SwitchPlate(visiblePlates[currentIndex - 1].id, scrollTo: true);
+            }
+            if (!hasPrev) ImGui.EndDisabled();
+
+            ImGui.TableNextColumn();
+            var hasNext = currentIndex >= 0 && currentIndex < visiblePlates.Count - 1;
+            if (!hasNext) ImGui.BeginDisabled();
+            if (Util.IconButton(FontAwesomeIcon.ChevronRight, tooltip: "Next plate")) {
+                this.SwitchPlate(visiblePlates[currentIndex + 1].id, scrollTo: true);
+            }
+            if (!hasNext) ImGui.EndDisabled();
 
             ImGui.EndTable();
         }
@@ -1525,6 +1554,13 @@ namespace Glamaholic.Ui {
             this._timedMessages[message] = timer;
         }
 
+        private List<(Guid id, PlateNode plate)> GetVisiblePlates() {
+            var all = TreeUtils.GetAllPlates(this.Ui.Plugin.Config.Plates);
+            return this.PlateFilter is null
+                ? all
+                : all.Where(p => this.PlateFilter.Matches(p.plate.Plate)).ToList();
+        }
+
         internal void SwitchPlate(Guid plateId, bool scrollTo = false) {
             this._selectedPlateId = plateId;
             this._scrollToSelected = scrollTo;
@@ -1533,6 +1569,12 @@ namespace Glamaholic.Ui {
             this._deleteConfirm = false;
             this._timedMessages.Clear();
             this.ResetEditing();
+
+            if (this.Ui.Plugin.Config.SyncTryOnWithSelection && Util.IsTryingOn(Service.GameGui)) {
+                if (TreeUtils.FindNodeById(this.Ui.Plugin.Config.Plates, plateId) is PlateNode plateNode) {
+                    this.Ui.TryOnHelper.TryOnPlate(plateNode.Plate);
+                }
+            }
         }
 
         private void ResetEditing() {

--- a/Glamaholic/Util.cs
+++ b/Glamaholic/Util.cs
@@ -11,6 +11,7 @@ namespace Glamaholic {
         internal const string PlateAddon = "MiragePrismMiragePlate";
         private const string BoxAddon = "MiragePrismPrismBox";
         private const string ArmoireAddon = "CabinetWithdraw";
+        private const string TryOnAddon = "Tryon";
 
         internal const uint HqItemOffset = 1_000_000; // The XIV code uses 500,000 but I'll trust this
         internal const uint ItemModifierMod = 500_000;
@@ -30,6 +31,10 @@ namespace Glamaholic {
             var armoireOpen = IsOpen(gui, ArmoireAddon);
 
             return plateOpen && (boxOpen || armoireOpen);
+        }
+
+        internal static bool IsTryingOn(IGameGui gui) {
+            return IsOpen(gui, TryOnAddon);
         }
 
         internal static bool DrawTextInput(string id, ref string input, int max = 512, string message = "Press Enter to save.", ImGuiInputTextFlags flags = ImGuiInputTextFlags.None) {


### PR DESCRIPTION
## Summary
- Add prev/next chevron buttons to the plate detail panel for stepping through the visible plate list
- Add a "Sync try on with selected plate" Settings option (default on) that mirrors the currently selected plate into
the in-game try-on window whenever it's open

## Motivation

With longer plate lists, browsing to compare similar glamours involves repeated click-and-try-on cycles. Two related
improvements:

1. Chevron buttons let you step through the (filtered) plate list without leaving the detail panel.
2. Once the try-on window is open, it would be helpful to have an option for the dressing room to follow whichever plate is currently selected, regardless of how you got there. Previously, only the magnifying-glass button would update try-on.

## Changes

- **Prev/next plate navigation** — Chevron buttons on the plate detail panel step through the visible plate list (respecting any active search filter) and disabling at the first/last entry.
- **Try-on follows selection** — When the in-game try-on window is open, any plate switch (chevron, list click, search-result click) mirrors into the dressing room. Controlled by a new "Sync try on with selected plate" toggle in the Settings menu (default on).
- **Internal** — Centralized try-on sync in `SwitchPlate()` so every selection path goes through one gated call, instead of duplicating the logic per call site.

## Testing

Tested in-game:
- Chevrons step through the visible plate list
- Chevrons disable at the first/last plate
- With the try-on window open and the setting on, switching plates via chevrons, list clicks, and search-result clicks
 all update the dressing room
- With the try-on window closed, switching is silent (no try-on calls)
- With the setting off, only the magnifying-glass button triggers try-on; chevrons and list clicks just change the
selection
- Setting toggle persists across plugin reload
